### PR TITLE
min and max can be equal 0. replace comma with dot in slider

### DIFF
--- a/frontend/src/app/(protected)/(stack)/measurement/createMeasurement/index.tsx
+++ b/frontend/src/app/(protected)/(stack)/measurement/createMeasurement/index.tsx
@@ -328,12 +328,15 @@ const CreateMeasurement: React.FC = () => {
     value: string,
     step: number = 1
   ) => {
+    // Reemplazar comas por puntos
+    const normalizedValue = value.replace(',', '.');
+
     setValues((prevValues) => ({
       ...prevValues,
-      [key]: value,
+      [key]: normalizedValue,
     }));
 
-    if (value === '') {
+    if (normalizedValue === '') {
       setErrors((prevErrors) => ({
         ...prevErrors,
         [name]: 'El campo no puede estar vacío.',
@@ -346,7 +349,7 @@ const CreateMeasurement: React.FC = () => {
       return;
     }
 
-    const numericValue = parseFloat(value);
+    const numericValue = parseFloat(normalizedValue);
     if (!isNaN(numericValue)) {
       // Validar rango
       if (numericValue < min || numericValue > max) {

--- a/frontend/src/i18n/locales/en-US/translation.json
+++ b/frontend/src/i18n/locales/en-US/translation.json
@@ -25,7 +25,7 @@
       "maxOptimoInvalid": "The optimal maximum value must be greater than the optimal minimum value and less than the maximum value.",
       "minOptimoGreaterThanMaxOptimo": "The optimal minimum value must be less than the optimal maximum value.",
       "maxOptimoLessThanMinOptimo": "The optimal maximum value must be greater than the optimal minimum value.",
-      "minMaxInvalid": "Both the minimum and maximum value must be greater than 0.",
+      "minMaxInvalid": "Both the minimum and maximum value must be greater or equal than 0.",
       "invalidCategoricalLength": "There must be at least 2 defined values.",
       "invalidTypeObjectLength": "You must select at least one object type."
     },

--- a/frontend/src/utils/validation/validationRules.tsx
+++ b/frontend/src/utils/validation/validationRules.tsx
@@ -67,7 +67,7 @@ export const useValidationRules = () => {
       errors.minMax = t('formErrors.range.minGreaterThanMax');
     }
 
-    if (min <= 0 || max <= 0) {
+    if (min < 0 || max < 0) {
       errors.minMax = t('formErrors.range.minMaxInvalid');
     }
 


### PR DESCRIPTION
This PR fixes two issues. One is that replaces commas by dots. When you try to measure a decimal value, you can't put a value using the keyboard because the keyboard puts a comma instead of dots

The second issue is when you create a new variable, it doesn't allow to put 0 as minimum value